### PR TITLE
fix(ci): wire secret env vars into cloud build steps

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -50,26 +50,36 @@ steps:
     waitFor: ["npm-install"]
     entrypoint: npm
     args: [run, build]
+    secretEnv:
+      - "CLOUD_RUN_URL"
+      - "FIREBASE_API_KEY"
+      - "FIREBASE_AUTH_DOMAIN"
+      - "FIREBASE_STORAGE_BUCKET"
+      - "FIREBASE_MESSAGING_SENDER_ID"
+      - "FIREBASE_APP_ID"
+      - "GA4_MEASUREMENT_ID"
     env:
-      - "VITE_API_URL=$$CLOUD_RUN_URL"
-      - "VITE_FIREBASE_API_KEY=$$FIREBASE_API_KEY"
-      - "VITE_FIREBASE_AUTH_DOMAIN=$$FIREBASE_AUTH_DOMAIN"
+      - "VITE_API_URL=$CLOUD_RUN_URL"
+      - "VITE_FIREBASE_API_KEY=$FIREBASE_API_KEY"
+      - "VITE_FIREBASE_AUTH_DOMAIN=$FIREBASE_AUTH_DOMAIN"
       - "VITE_FIREBASE_PROJECT_ID=amplify-interview-e6bf5"
-      - "VITE_FIREBASE_STORAGE_BUCKET=$$FIREBASE_STORAGE_BUCKET"
-      - "VITE_FIREBASE_MESSAGING_SENDER_ID=$$FIREBASE_MESSAGING_SENDER_ID"
-      - "VITE_FIREBASE_APP_ID=$$FIREBASE_APP_ID"
-      - "VITE_GA4_MEASUREMENT_ID=$$GA4_MEASUREMENT_ID"
+      - "VITE_FIREBASE_STORAGE_BUCKET=$FIREBASE_STORAGE_BUCKET"
+      - "VITE_FIREBASE_MESSAGING_SENDER_ID=$FIREBASE_MESSAGING_SENDER_ID"
+      - "VITE_FIREBASE_APP_ID=$FIREBASE_APP_ID"
+      - "VITE_GA4_MEASUREMENT_ID=$GA4_MEASUREMENT_ID"
 
   # ── Frontend: Deploy to Firebase Hosting ──────────────────────────────────
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "deploy-hosting"
     waitFor: ["npm-build"]
     entrypoint: bash
+    secretEnv:
+      - "FIREBASE_TOKEN"
     args:
       - -c
       - |
         npm install -g firebase-tools
-        firebase deploy --only hosting --token $$FIREBASE_TOKEN --project amplify-interview-e6bf5
+        firebase deploy --only hosting --token "$FIREBASE_TOKEN" --project amplify-interview-e6bf5
 
 availableSecrets:
   secretManager:


### PR DESCRIPTION
Attach Secret Manager env vars to npm build and firebase deploy steps so Cloud Build treats them as used.