### PR TITLE
fix(ci): escape secret env vars to avoid Cloud Build substitutions

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -59,14 +59,15 @@ steps:
       - "FIREBASE_APP_ID"
       - "GA4_MEASUREMENT_ID"
     env:
-      - "VITE_API_URL=$CLOUD_RUN_URL"
-      - "VITE_FIREBASE_API_KEY=$FIREBASE_API_KEY"
-      - "VITE_FIREBASE_AUTH_DOMAIN=$FIREBASE_AUTH_DOMAIN"
+      # Use $$ to avoid Cloud Build substitution; values expand at runtime from secretEnv.
+      - "VITE_API_URL=$$CLOUD_RUN_URL"
+      - "VITE_FIREBASE_API_KEY=$$FIREBASE_API_KEY"
+      - "VITE_FIREBASE_AUTH_DOMAIN=$$FIREBASE_AUTH_DOMAIN"
       - "VITE_FIREBASE_PROJECT_ID=amplify-interview-e6bf5"
-      - "VITE_FIREBASE_STORAGE_BUCKET=$FIREBASE_STORAGE_BUCKET"
-      - "VITE_FIREBASE_MESSAGING_SENDER_ID=$FIREBASE_MESSAGING_SENDER_ID"
-      - "VITE_FIREBASE_APP_ID=$FIREBASE_APP_ID"
-      - "VITE_GA4_MEASUREMENT_ID=$GA4_MEASUREMENT_ID"
+      - "VITE_FIREBASE_STORAGE_BUCKET=$$FIREBASE_STORAGE_BUCKET"
+      - "VITE_FIREBASE_MESSAGING_SENDER_ID=$$FIREBASE_MESSAGING_SENDER_ID"
+      - "VITE_FIREBASE_APP_ID=$$FIREBASE_APP_ID"
+      - "VITE_GA4_MEASUREMENT_ID=$$GA4_MEASUREMENT_ID"
 
   # ── Frontend: Deploy to Firebase Hosting ──────────────────────────────────
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
@@ -79,7 +80,8 @@ steps:
       - -c
       - |
         npm install -g firebase-tools
-        firebase deploy --only hosting --token "$FIREBASE_TOKEN" --project amplify-interview-e6bf5
+        # Use $$ to avoid Cloud Build substitution; expanded by bash from secretEnv.
+        firebase deploy --only hosting --token "$$FIREBASE_TOKEN" --project amplify-interview-e6bf5
 
 availableSecrets:
   secretManager:


### PR DESCRIPTION
Use $$VAR in env/script so Secret Manager values expand at runtime, not during build config parsing.